### PR TITLE
Core podspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ it, simply add the following line to your `Podfile`:
 pod "Segment-Appboy"
 ```
 
+If you are only using `Appboy-iOS-SDK/Core` as a dependency, then instead, your podfile should read:
+
+```ruby
+pod "Segment-Appboy/Core"
+```
+
+
 ## Usage
 
 After adding the dependency, you must register the integration with our SDK. To do this, import the Braze integration in your AppDelegate:

--- a/Segment-Appboy.podspec
+++ b/Segment-Appboy.podspec
@@ -20,8 +20,15 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.source_files = 'Pod/Classes/**/*'
-
   s.dependency 'Analytics', '~> 3.0'
-  s.dependency 'Appboy-iOS-SDK'
 
+  s.default_subspec = 'Full-SDK'
+
+  s.subspec 'Full-SDK' do |default|
+    default.dependency 'Appboy-iOS-SDK/'
+  end
+
+  s.subspec 'Core' do |core|
+    core.dependency 'Appboy-iOS-SDK/Core'
+  end
 end


### PR DESCRIPTION
For those that only need `Appboy-iOS-SDK/Core` as a dependency, it doesn't make sense to have a _different_ dependency (i.e., this library) overrule them.

Users can now require `pod 'Segment-Appboy/Core'` in order to achieve this. The default of requiring the full Appboy sdk is preserved via a default subspec.