### PR TITLE
Handle push payload received in inactive state on the main thread.

### DIFF
--- a/Pod/Classes/SEGAppboyIntegration.m
+++ b/Pod/Classes/SEGAppboyIntegration.m
@@ -266,10 +266,12 @@
     // The existence of a push payload saved on the factory indicates that the push was received when
     // Appboy was not initialized yet, and thus the push was received in the inactive state.
     if ([[Appboy sharedInstance] respondsToSelector:@selector(handleRemotePushNotification:withIdentifier:completionHandler:applicationState:)]) {
-      [[Appboy sharedInstance] handleRemotePushNotification:pushDictionary
-                                             withIdentifier:identifier
-                                          completionHandler:nil
-                                           applicationState:UIApplicationStateInactive];
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [[Appboy sharedInstance] handleRemotePushNotification:pushDictionary
+                                               withIdentifier:identifier
+                                            completionHandler:nil
+                                             applicationState:UIApplicationStateInactive];
+      });
     }
     [[SEGAppboyIntegrationFactory instance] saveRemoteNotification:nil];
     return YES;


### PR DESCRIPTION
When launching the app from a push notification, coming from the inactive state, this method is invoked from a background thread, all the other methods executed in the middleware are invoked from the main thread but this one, which caused a crash case when launching from a push notification and then making changes on the UI to navigate to the given Universal Link.

To further complicate this, it is common to perform some internal logic when receiving a deep link, which usually runs some asynchronous code that uses PromiseKit/RxSwift code, and those libraries automatically handle threading, which caused some universal links to fail while others work fine.