### PR TITLE
Bugfix/UI code called on background thread

### DIFF
--- a/Pod/Classes/SEGAppboyIntegration.m
+++ b/Pod/Classes/SEGAppboyIntegration.m
@@ -276,7 +276,9 @@
 
 - (void)handleActionWithIdentifier:(NSString *)identifier forRemoteNotification:(NSDictionary *)userInfo {
   if (![self logPushIfComesInBeforeAppboyInitializedWithIdentifier:identifier]) {
-    [[Appboy sharedInstance] getActionWithIdentifier:identifier forRemoteNotification:userInfo completionHandler:nil];
+      dispatch_async(dispatch_get_main_queue(), ^{
+          [[Appboy sharedInstance] getActionWithIdentifier:identifier forRemoteNotification:userInfo completionHandler:nil];
+      });
   }
   SEGLog(@"[[Appboy sharedInstance] getActionWithIdentifier: forRemoteNotification: completionHandler:]");
 }


### PR DESCRIPTION
I noticed this issue being raised when performing the following steps:
1. Have Appboy-iOS-SDK `Core` and `InAppMessage` subspecs pulled in as dependencies
2. Initialize `Appboy` on startup
3. Background our app
4. Test an In-App Message from the Braze Dashboard (received as a push notification trigger)
5. Tap the push notification
6. App opens and the following warning is printed in the console:
```
Main Thread Checker: UI API called on a background thread: -[UIApplication applicationState]
PID: 11342, TID: 2651309, Thread name: (none), Queue name: io.segment.analytics, QoS: 0
Backtrace:
4   Appboy_iOS_SDK                      0x0000000104860af4 -[Appboy handleRemotePushNotification:withIdentifier:completionHandler:] + 196
5   Appboy_iOS_SDK                      0x00000001048606e0 -[Appboy getActionWithIdentifier:forRemoteNotification:completionHandler:] + 244
6   Segment_Appboy                      0x000000010550dcc0 -[SEGAppboyIntegration handleActionWithIdentifier:forRemoteNotification:] + 192
7   CoreFoundation                      0x000000019b878c20 7519E999-1053-3367-B9D5-8844F6D3BDC6 + 1252384
8   CoreFoundation                      0x000000019b748d30 7519E999-1053-3367-B9D5-8844F6D3BDC6 + 7472
9   CoreFoundation                      0x000000019b749908 7519E999-1053-3367-B9D5-8844F6D3BDC6 + 10504
10  Analytics                           0x0000000104757ba0 -[SEGIntegrationsManager invokeIntegration:key:selector:arguments:options:] + 988
11  Analytics                           0x0000000104757684 __60-[SEGIntegrationsManager forwardSelector:arguments:options:]_block_invoke + 140
12  CoreFoundation                      0x000000019b8bfd74 7519E999-1053-3367-B9D5-8844F6D3BDC6 + 1543540
13  CoreFoundation                      0x000000019b7497dc 7519E999-1053-3367-B9D5-8844F6D3BDC6 + 10204
14  Analytics                           0x0000000104757580 -[SEGIntegrationsManager forwardSelector:arguments:options:] + 276
15  Analytics                           0x00000001047585d4 __78-[SEGIntegrationsManager callIntegrationsWithSelector:arguments:options:sync:]_block_invoke + 124
16  Analytics                           0x000000010474de58 __seg_dispatch_specific_block_invoke + 60
17  libdispatch.dylib                   0x00000001065357fc _dispatch_call_block_and_release + 24
18  libdispatch.dylib                   0x0000000106536bd8 _dispatch_client_callout + 16
19  libdispatch.dylib                   0x000000010653db48 _dispatch_lane_serial_drain + 744
20  libdispatch.dylib                   0x000000010653e6e4 _dispatch_lane_invoke + 448
21  libdispatch.dylib                   0x0000000106549adc _dispatch_workloop_worker_thread + 1324
22  libsystem_pthread.dylib             0x000000019b58eb88 _pthread_wqthread + 276
23  libsystem_pthread.dylib             0x000000019b591760 start_wqthread + 8
```