### PR TITLE
Feature/reduce Appboy SDK static library size

### DIFF
--- a/CarthageExample/Cartfile.resolved
+++ b/CarthageExample/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "appboy/appboy-ios-sdk" "3.23.0"
-github "appboy/appboy-segment-ios" "3.1.0"
-github "segmentio/analytics-ios" "3.8.2"
+github "appboy/appboy-ios-sdk" "3.25.0"
+github "appboy/appboy-segment-ios" "3.2.0"
+github "segmentio/analytics-ios" "4.0.4"

--- a/Segment-Appboy.podspec
+++ b/Segment-Appboy.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Segment-Appboy"
-  s.version          = "3.2.0"
+  s.version          = "3.3.0"
   s.summary          = "Braze Integration for Segment's analytics-ios library."
 
   s.description      = <<-DESC
@@ -22,27 +22,27 @@ Pod::Spec.new do |s|
   s.default_subspec = 'Full-SDK'
 
   s.subspec 'Full-SDK' do |default|
-    default.dependency 'Appboy-iOS-SDK', '~>3.24.1'
+    default.dependency 'Appboy-iOS-SDK', '~>3.25.0'
     default.source_files = 'Pod/Classes/**/*'
   end
 
   s.subspec 'Core' do |core|
-    core.dependency 'Appboy-iOS-SDK/Core', '~>3.24.1'
+    core.dependency 'Appboy-iOS-SDK/Core', '~>3.25.0'
     core.source_files = 'Pod/Classes/**/*'
   end
   
   s.subspec 'InAppMessage' do |iam|
-    iam.dependency 'Appboy-iOS-SDK/InAppMessage', '~>3.24.1'
+    iam.dependency 'Appboy-iOS-SDK/InAppMessage', '~>3.25.0'
     iam.source_files = 'Pod/Classes/**/*'
   end
   
   s.subspec 'NewsFeed' do |nf|
-    nf.dependency 'Appboy-iOS-SDK/NewsFeed', '~>3.24.1'
+    nf.dependency 'Appboy-iOS-SDK/NewsFeed', '~>3.25.0'
     nf.source_files = 'Pod/Classes/**/*'
   end
   
   s.subspec 'ContentCards' do |cc|
-    cc.dependency 'Appboy-iOS-SDK/ContentCards', '~>3.24.1'
+    cc.dependency 'Appboy-iOS-SDK/ContentCards', '~>3.25.0'
     cc.source_files = 'Pod/Classes/**/*'
   end
 


### PR DESCRIPTION
### Description
- Bumped `podspec` version to `3.3.0`
- Updated `Appboy-iOS-SDK` dependency to `3.25.0`, which reduces the static library file size to be under Github's 100MB limit
- Ran a `carthage update` in the `CarthageExample` project