### PR TITLE
Use optimise version of Braze iOS SDK for SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
   ],
   dependencies: [
     .package(name: "Segment", url: "https://github.com/segmentio/analytics-ios.git", from: "4.1.1"),
-    .package(name: "Appboy_iOS_SDK", url: "https://github.com/Appboy/appboy-ios-sdk.git", from: "4.3.0"),
+    .package(name: "Appboy_iOS_SDK", url: "https://github.com/braze-inc/braze-ios-sdk", from: "4.4.1"),
   ],
   targets: [
     .target(


### PR DESCRIPTION
Base on https://github.com/Appboy/appboy-ios-sdk/issues/289
Using https://github.com/Appboy/appboy-ios-sdk instead of https://github.com/braze-inc/braze-ios-sdk when using SPM will increase the size of the repo (1.42 GB). 

Braze [documentation](https://www.braze.com/docs/developer_guide/platform_integration_guides/ios/initial_sdk_setup/installation_methods/swift_package_manager/?redirected=true#step-1-adding-the-dependency-to-your-project) advise to use https://github.com/braze-inc/braze-ios-sdk instead