### PR TITLE
Fixed an issue where empty properties wouldn't be sent to Braze

### DIFF
--- a/CocoapodsExample/Segment-Appboy.xcodeproj/project.pbxproj
+++ b/CocoapodsExample/Segment-Appboy.xcodeproj/project.pbxproj
@@ -58,7 +58,7 @@
 		6003F5AF195388D20070C39A /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		6003F5B7195388D20070C39A /* Tests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Tests-Info.plist"; sourceTree = "<group>"; };
 		6003F5B9195388D20070C39A /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		6003F5BB195388D20070C39A /* SEGAppboyIntegrationTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SEGAppboyIntegrationTest.m; sourceTree = "<group>"; };
+		6003F5BB195388D20070C39A /* SEGAppboyIntegrationTest.m */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = SEGAppboyIntegrationTest.m; sourceTree = "<group>"; tabWidth = 2; };
 		606FC2411953D9B200FFA9A0 /* Tests-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Tests-Prefix.pch"; sourceTree = "<group>"; };
 		873B8AEA1B1F5CCA007FD442 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		A3F2E40E91ECF99EB610E19D /* Pods-Segment-Appboy_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Segment-Appboy_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-Segment-Appboy_Example/Pods-Segment-Appboy_Example.release.xcconfig"; sourceTree = "<group>"; };

--- a/CocoapodsExample/Tests/SEGAppboyIntegrationTest.m
+++ b/CocoapodsExample/Tests/SEGAppboyIntegrationTest.m
@@ -199,6 +199,23 @@ describe(@"SEGAppboyIntegration", ^{
       [appboyIntegration track:trackPayload];
       OCMVerifyAllWithDelay(appboyMock, 2);
     });
+
+    it(@"logs an event if there isn't revenue nor properties", ^{
+      NSDictionary *settings = @{@"apiKey":@"foo"};
+      id appboyMock = OCMClassMock([Appboy class]);
+      OCMStub([appboyMock sharedInstance]).andReturn(appboyMock);
+      OCMExpect([appboyMock startWithApiKey:@"foo" inApplication:[OCMArg any] withLaunchOptions:nil withAppboyOptions:[OCMArg any]]);
+      OCMExpect([appboyMock logCustomEvent:@"testEvent"]);
+
+      SEGAppboyIntegration *appboyIntegration = [[SEGAppboyIntegration alloc] initWithSettings:settings];
+
+      SEGTrackPayload *trackPayload = [[SEGTrackPayload alloc] initWithEvent:@"testEvent"
+                                                                  properties:nil
+                                                                     context:nil
+                                                                integrations:nil];
+      [appboyIntegration track:trackPayload];
+      OCMVerifyAllWithDelay(appboyMock, 2);
+    });
   });
   
   describe(@"flush", ^{

--- a/Pod/Classes/SEGAppboyIntegration.m
+++ b/Pod/Classes/SEGAppboyIntegration.m
@@ -249,7 +249,12 @@
     }
     SEGLog(@"[[Appboy sharedInstance] logPurchase: inCurrency: atPrice: withQuantity:]");
   } else {
-    [[Appboy sharedInstance] logCustomEvent:payload.event withProperties:payload.properties];
+    if (payload.properties.count == 0) {
+        [[Appboy sharedInstance] logCustomEvent:payload.event];
+    } else {
+        [[Appboy sharedInstance] logCustomEvent:payload.event withProperties:payload.properties];
+    }
+
     SEGLog(@"[[Appboy sharedInstance] logCustomEvent: withProperties:]");
   }
 }


### PR DESCRIPTION
# Changelog
Fixed an issue where any event without properties wouldn't be sent to Braze SDK due to inaccurate mapping. Ideally, the [Braze SDK](https://github.com/Appboy/appboy-ios-sdk) (closed source) should handle `nil` and `empty` dictionary of properties the same way. As the SDK is closed sourced, I've instead add the check in this project's mapping function to ensure the it's calling the correct Braze method for custom event logging.

Fixes invalid properties warning with test case:
```
[APPBOY][WARN] -[Appboy logCustomEvent:withProperties:] Not logging custom event with event name: <event_name>. Reason: invalid properties
```

Any event that has properties works fine in Side-by-Side integration. This patch makes it work for events that has no or empty properties.

Segment SDK internally calls [SEGCoerceDictionary](https://github.com/segmentio/analytics-ios/blob/master/Segment/Internal/SEGUtils.m#L518-L525) method before passing the event to integrations. The method converts any null dictionary to empty dictionary.

## Related Issues
This issue fixes: https://github.com/segmentio/analytics-ios/pull/1027 and https://github.com/segmentio/analytics-ios/issues/967 as both of those issues stem from this underlying issue where the wrapping incorrect mapping empty properties to SDK which doesn't accept empty dictionary. Ideally, the Braze SDK should log these as errors and not warnings **as the impact is data loss.**